### PR TITLE
Add all seven of the javafx modules to JavaBuild.java

### DIFF
--- a/java/src/processing/mode/java/JavaBuild.java
+++ b/java/src/processing/mode/java/JavaBuild.java
@@ -1083,7 +1083,9 @@ public class JavaBuild {
       // Full list of modules, let's not commit to all of these unless
       // a compelling argument is made or a reason presents itself.
       //"javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web"
-      "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
+    // *****  "--add-modules", "javafx.base,javafx.graphics,javafx.swing",
+   // *****   change to:
+       "--add-modules", "javafx.base,javafx.graphics,javafx.swing,javafx.controls,javafx.media,javafx.web,javafx.fxml",
 
       // TODO Presumably, this is only because com.sun.* classes are being used?
       // https://github.com/processing/processing4/issues/208


### PR DESCRIPTION
Please add _all seven of the javafx modules so that we may use JavaFX controls in our apps. Thanks.